### PR TITLE
fixed import paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Every sentry application defined on the server gets a different
 ```go
 import (
   "github.com/Sirupsen/logrus"
-  "github.com/Sirupsen/logrus/hooks/sentry"
+  "github.com/evalphobia/logrus_sentry"
 )
 
 func main() {
@@ -52,7 +52,7 @@ the `NewWithClientSentryHook` constructor:
 ```go
 import (
   "github.com/Sirupsen/logrus"
-  "github.com/Sirupsen/logrus/hooks/sentry"
+  "github.com/evalphobia/logrus_sentry"
   "github.com/getsentry/raven-go"
 )
 


### PR DESCRIPTION
As the title says, the import paths in the ```README.md``` were still pointing at the in-tree version of the plugin.