### PR TITLE
Add special sentry field support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,21 @@ hook, err := NewWithClientSentryHook(client, []logrus.Level{
 
 ## Special fields
 
-Some logrus fields have a special meaning in this hook,
-these are `server_name`, `logger` and `http_request`.
-When logs are sent to sentry these fields are treated differently.
-- `server_name` (also known as hostname) is the name of the server which
-is logging the event (hostname.example.com)
-- `logger` is the part of the application which is logging the event.
-In go this usually means setting it to the name of the package.
-- `http_request` is the in-coming request(*http.Request). The detailed request data are sent to Sentry.
+Some logrus fields have a special meaning in this hook, and they will be especially processed by Sentry.
+
+
+| Field key  | Description |
+| ------------- | ------------- |
+| `event_id`  | Each logged event is identified by the `event_id`, which is hexadecimal string representing a UUID4 value. You can manually specify the identifier of a log event by supplying this field.  The `event_id` string should be in one of the following UUID format: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` and `urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`)|
+| `user_name`  | Name of the user who is in the context of the event  |
+| `user_email`  | Email of the user who is in the context of the event |
+| `user_id`  | ID of the user who is in the context of the event |
+| `user_ip`  | IP of the user who is in the context of the event |
+| `server_name`  | Also known as hostname, it is the name of the server which is logging the event (hostname.example.com)  |
+| `logger`  | `logger` is the part of the application which is logging the event. In go this usually means setting it to the name of the package. |
+| `http_request`  | `http_request` is the in-coming request(*http.Request). The detailed request data are sent to Sentry. |
+
+
 
 ## Timeout
 

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -33,7 +33,7 @@ func getTestLogger() *logrus.Logger {
 // so need to explicitly construct one for purpose of test
 type resultPacket struct {
 	raven.Packet
-	Stacktrace raven.Stacktrace `json:stacktrace`
+	Stacktrace raven.Stacktrace `json:"stacktrace"`
 }
 
 func WithTestDSN(t *testing.T, tf func(string, <-chan *resultPacket)) {
@@ -206,7 +206,7 @@ func TestSentryStacktrace(t *testing.T) {
 			t.Errorf("File name should have ended with %s, was %s", expectedSuffix, lastFrame.Filename)
 		}
 		if lastFrame.Lineno != expectedLineno {
-			t.Errorf("Line number should have been %s, was %s", expectedLineno, lastFrame.Lineno)
+			t.Errorf("Line number should have been %d, was %d", expectedLineno, lastFrame.Lineno)
 		}
 		if lastFrame.InApp {
 			t.Error("Frame should not be identified as in_app without prefixes")

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,135 @@
+package logrus_sentry
+
+import (
+	"fmt"
+	"strings"
+)
+
+/*
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
+// 4122.
+type uuid []byte
+
+// parseUUID decodes s into a UUID or returns nil.  Both the UUID form of
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx and
+// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx and
+// urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx are decoded.
+func parseUUID(s string) uuid {
+	//If it is in no dash format "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	if len(s) == 32 {
+		uuid := make([]byte, 16)
+		for i, x := range []int{
+			0, 2, 4, 6, 8, 10,
+			12, 14, 16, 18, 20,
+			22, 24, 26, 28, 30} {
+			if v, ok := xtob(s[x:]); !ok {
+				return nil
+			} else {
+				uuid[i] = v
+			}
+		}
+		return uuid
+	}
+
+	if len(s) == 36+9 {
+		if strings.ToLower(s[:9]) != "urn:uuid:" {
+			return nil
+		}
+		s = s[9:]
+	} else if len(s) != 36 {
+		return nil
+	}
+	if s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-' {
+		return nil
+	}
+	uuid := make([]byte, 16)
+	for i, x := range []int{
+		0, 2, 4, 6,
+		9, 11,
+		14, 16,
+		19, 21,
+		24, 26, 28, 30, 32, 34} {
+		if v, ok := xtob(s[x:]); !ok {
+			return nil
+		} else {
+			uuid[i] = v
+		}
+	}
+	return uuid
+}
+
+// String returns the string form of uuid, xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+// , or "" if uuid is invalid.
+func (uuid uuid) string() string {
+	if uuid == nil || len(uuid) != 16 {
+		return ""
+	}
+	b := []byte(uuid)
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+func (uuid uuid) noDashString() string {
+	if uuid == nil || len(uuid) != 16 {
+		return ""
+	}
+	b := []byte(uuid)
+	return fmt.Sprintf("%08x%04x%04x%04x%012x",
+		b[:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+// xvalues returns the value of a byte as a hexadecimal digit or 255.
+var xvalues = []byte{
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 255, 255, 255, 255, 255, 255,
+	255, 10, 11, 12, 13, 14, 15, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 10, 11, 12, 13, 14, 15, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+}
+
+// xtob converts the the first two hex bytes of x into a byte.
+func xtob(x string) (byte, bool) {
+	b1 := xvalues[x[0]]
+	b2 := xvalues[x[1]]
+	return (b1 << 4) | b2, b1 != 255 && b2 != 255
+}


### PR DESCRIPTION
Fix errors from go vet 
```
$ go vet
sentry_test.go:36: struct field tag `json:stacktrace` not compatible with reflect.StructTag.Get
sentry_test.go:209: arg expectedLineno for printf verb %s of wrong type: int
```