### PR TITLE
Reverse the culprit and the message for better grouping

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -213,7 +213,8 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 		if err, ok := getAndDelError(d, logrus.ErrorKey); ok {
 			exc := raven.NewException(err, currentStacktrace)
 			packet.Interfaces = append(packet.Interfaces, exc)
-			packet.Culprit = err.Error()
+			packet.Culprit = entry.Message
+			packet.Message = err.Error()
 		} else {
 			packet.Interfaces = append(packet.Interfaces, currentStacktrace)
 		}


### PR DESCRIPTION
Right now we're having multiple error messages grouped under the same heading because they use a common message. This switches the message to be the 'Culprit' so it will be grouped better, but still retain all useful information.