### PR TITLE
Use raven's default extra fields

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -144,7 +144,14 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 		}
 	}
 
-	packet.Extra = hook.formatExtraData(d)
+	dataExtra := hook.formatExtraData(d)
+	if packet.Extra == nil {
+		packet.Extra = dataExtra
+	} else {
+		for k, v := range dataExtra {
+			packet.Extra[k] = v
+		}
+	}
 
 	_, errCh := hook.client.Capture(packet, nil)
 	timeout := hook.Timeout

--- a/sentry.go
+++ b/sentry.go
@@ -102,12 +102,11 @@ func NewWithClientSentryHook(client *raven.Client, levels []logrus.Level) (*Sent
 // are extracted from entry.Data (if they are found)
 // These fields are: error, logger, server_name and http_request
 func (hook *SentryHook) Fire(entry *logrus.Entry) error {
-	packet := &raven.Packet{
-		Message:   entry.Message,
-		Timestamp: raven.Timestamp(entry.Time),
-		Level:     severityMap[entry.Level],
-		Platform:  "go",
-	}
+
+	packet := raven.NewPacket(entry.Message)
+	packet.Timestamp = raven.Timestamp(entry.Time)
+	packet.Level = severityMap[entry.Level]
+	packet.Platform = "go"
 
 	d := entry.Data
 


### PR DESCRIPTION
raven has some useful default 'extra' fields which are added when creating a packet with `raven.NewPacket`. These commits allow using the default fields as well the additional fields provided by the `logrus.Entry`.