### PR TITLE
Add support for github.com/pkg/errors interfaces

### DIFF
--- a/sentry_test.go
+++ b/sentry_test.go
@@ -240,7 +240,7 @@ func TestSentryStacktrace(t *testing.T) {
 		if packet.Exception.Stacktrace != nil {
 			frames = packet.Exception.Stacktrace.Frames
 		}
-		if len(frames) != 1 || frames[0].Filename != escpectedStackFrameFilename {
+		if len(frames) != 1 || frames[0].Filename != expectedStackFrameFilename {
 			t.Error("Stacktrace should be taken from err if it implements the Stacktracer interface")
 		}
 	})
@@ -408,12 +408,12 @@ type myStacktracerError struct{}
 
 func (myStacktracerError) Error() string { return "myStacktracerError!" }
 
-const escpectedStackFrameFilename = "errorFile.go"
+const expectedStackFrameFilename = "errorFile.go"
 
 func (myStacktracerError) GetStacktrace() *raven.Stacktrace {
 	return &raven.Stacktrace{
 		Frames: []*raven.StacktraceFrame{
-			{Filename: escpectedStackFrameFilename},
+			{Filename: expectedStackFrameFilename},
 		},
 	}
 }


### PR DESCRIPTION
This PR adds support for two interfaces, implemented by the [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors) package:

- The [causer](https://godoc.org/github.com/pkg/errors#hdr-Retrieving_the_cause_of_an_error) interface, which allows unwrapping errors which were wrapped by this package, to find the underlying cause.
- The [stackTracer](https://godoc.org/github.com/pkg/errors#hdr-Retrieving_the_stack_trace_of_an_error_or_wrapper) interface, which works in spirit the same as the `Stacktracer` interface introduced by https://github.com/evalphobia/logrus_sentry/commit/162f5c6ab032c7151ea4129cc1d2f22ace3d9a55
