### PR TITLE
Fix not to delete fields

### DIFF
--- a/data_field.go
+++ b/data_field.go
@@ -1,0 +1,124 @@
+package logrus_sentry
+
+import (
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/getsentry/raven-go"
+)
+
+const (
+	fieldEventID     = "event_id"
+	fieldLogger      = "logger"
+	fieldServerName  = "server_name"
+	fieldTags        = "tags"
+	fieldHTTPRequest = "http_request"
+	fieldUser        = "user"
+)
+
+type dataField struct {
+	data     logrus.Fields
+	omitList map[string]struct{}
+}
+
+func newDataField(data logrus.Fields) *dataField {
+	return &dataField{
+		data:     data,
+		omitList: make(map[string]struct{}),
+	}
+}
+
+func (d *dataField) len() int {
+	return len(d.data)
+}
+
+func (d *dataField) isOmit(key string) bool {
+	_, ok := d.omitList[key]
+	return ok
+}
+
+func (d *dataField) getLogger() (string, bool) {
+	if logger, ok := d.data[fieldLogger].(string); ok {
+		d.omitList[fieldLogger] = struct{}{}
+		return logger, true
+	}
+	return "", false
+}
+
+func (d *dataField) getServerName() (string, bool) {
+	if serverName, ok := d.data[fieldServerName].(string); ok {
+		d.omitList[fieldServerName] = struct{}{}
+		return serverName, true
+	}
+	return "", false
+}
+
+func (d *dataField) getTags() (raven.Tags, bool) {
+	if tags, ok := d.data[fieldTags].(raven.Tags); ok {
+		d.omitList[fieldTags] = struct{}{}
+		return tags, true
+	}
+	return nil, false
+}
+
+func (d *dataField) getError() (error, bool) {
+	if err, ok := d.data[logrus.ErrorKey].(error); ok {
+		d.omitList[logrus.ErrorKey] = struct{}{}
+		return err, true
+	}
+	return nil, false
+}
+
+func (d *dataField) getHTTPRequest() (*http.Request, bool) {
+	if req, ok := d.data[fieldHTTPRequest].(*http.Request); ok {
+		d.omitList[fieldHTTPRequest] = struct{}{}
+		return req, true
+	}
+	return nil, false
+}
+
+func (d *dataField) getEventID() (string, bool) {
+	eventID, ok := d.data[fieldEventID].(string)
+	if !ok {
+		return "", false
+	}
+
+	//verify eventID is 32 characters hexadecimal string (UUID4)
+	uuid := parseUUID(eventID)
+	if uuid == nil {
+		return "", false
+	}
+
+	d.omitList[fieldEventID] = struct{}{}
+	return uuid.noDashString(), true
+}
+
+func (d *dataField) getUser() (*raven.User, bool) {
+	data := d.data
+	if v, ok := data[fieldUser]; ok {
+		switch val := v.(type) {
+		case *raven.User:
+			d.omitList[fieldUser] = struct{}{}
+			return val, true
+		case raven.User:
+			d.omitList[fieldUser] = struct{}{}
+			return &val, true
+		}
+	}
+
+	username, _ := data["user_name"].(string)
+	email, _ := data["user_email"].(string)
+	id, _ := data["user_id"].(string)
+	ip, _ := data["user_ip"].(string)
+
+	if username == "" && email == "" && id == "" && ip == "" {
+		return nil, false
+	}
+
+	return &raven.User{
+		ID:       id,
+		Username: username,
+		Email:    email,
+		IP:       ip,
+	}, true
+}

--- a/data_field_test.go
+++ b/data_field_test.go
@@ -103,6 +103,9 @@ func TestGetLogger(t *testing.T) {
 		assert.Equal(tt.expected, ok, target)
 		if ok {
 			assert.Equal(tt.value, logger, target)
+			assert.True(df.isOmit("logger"), "`logger` should be in omitList")
+		} else {
+			assert.False(df.isOmit("logger"), "`logger` should not be in omitList")
 		}
 	}
 }
@@ -135,6 +138,9 @@ func TestGetServerName(t *testing.T) {
 		assert.Equal(tt.expected, ok, target)
 		if ok {
 			assert.Equal(tt.value, serverName, target)
+			assert.True(df.isOmit("server_name"), "`server_name` should be in omitList")
+		} else {
+			assert.False(df.isOmit("server_name"), "`server_name` should not be in omitList")
 		}
 	}
 }
@@ -151,6 +157,7 @@ func TestGetTags(t *testing.T) {
 		{"tags", raven.Tags{{Key: "key", Value: "value"}}, true, "valid tags"},
 		{"tags", raven.Tags{}, true, "valid tags"},
 		{"not_tags", raven.Tags{{Key: "key", Value: "value"}}, false, "invalid key"},
+		{"tags", &raven.Tags{}, false, "invalid value type"},
 		{"tags", "test_tags", false, "invalid value type"},
 		{"tags", 1, false, "invalid value type"},
 		{"tags", true, false, "invalid value type"},
@@ -168,6 +175,9 @@ func TestGetTags(t *testing.T) {
 		assert.Equal(tt.expected, ok, target)
 		if ok {
 			assert.Equal(tt.value, tags, target)
+			assert.True(df.isOmit("tags"), "`tags` should be in omitList")
+		} else {
+			assert.False(df.isOmit("tags"), "`tags` should not be in omitList")
 		}
 	}
 }
@@ -201,6 +211,9 @@ func TestGetError(t *testing.T) {
 		assert.Equal(tt.expected, ok, target)
 		if ok {
 			assert.Equal(tt.value, err, target)
+			assert.True(df.isOmit("error"), "`error` should be in omitList")
+		} else {
+			assert.False(df.isOmit("error"), "`error` should not be in omitList")
 		}
 	}
 }
@@ -234,6 +247,9 @@ func TestGetHTTPRequest(t *testing.T) {
 		assert.Equal(tt.expected, ok, target)
 		if ok {
 			assert.Equal(tt.value, req, target)
+			assert.True(df.isOmit("http_request"), "`http_request` should be in omitList")
+		} else {
+			assert.False(df.isOmit("http_request"), "`http_request` should not be in omitList")
 		}
 	}
 }
@@ -270,6 +286,9 @@ func TestGetEventID(t *testing.T) {
 		assert.Equal(tt.expected, ok, target)
 		if ok {
 			assert.Equal("ffffffffffffffffffffffffffffffff", eventID, target)
+			assert.True(df.isOmit("event_id"), "`event_id` should be in omitList")
+		} else {
+			assert.False(df.isOmit("event_id"), "`event_id` should not be in omitList")
 		}
 	}
 }
@@ -303,6 +322,9 @@ func TestGetUser(t *testing.T) {
 		assert.Equal(tt.expected, ok, target)
 		if ok {
 			assert.IsType(&raven.User{}, user, target)
+			assert.True(df.isOmit("user"), "`user` should be in omitList")
+		} else {
+			assert.False(df.isOmit("user"), "`user` should not be in omitList")
 		}
 	}
 }

--- a/data_field_test.go
+++ b/data_field_test.go
@@ -1,0 +1,352 @@
+package logrus_sentry
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/getsentry/raven-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLen(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		fieldSize int
+	}{
+		{0},   // empty fileds
+		{1},   // "0"
+		{2},   // "0", "1"
+		{9},   // "0", "1", "2" ... "8"
+		{100}, // "0", "1", "2" ... "99"
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		for i, max := 0, tt.fieldSize; i < max; i++ {
+			fields[strconv.Itoa(i)] = struct{}{}
+		}
+
+		df := dataField{
+			data: fields,
+		}
+		assert.Equal(tt.fieldSize, df.len(), "dataField.Len() should equal fieldSize", target)
+	}
+}
+
+func TestIsOmit(t *testing.T) {
+	assert := assert.New(t)
+
+	omitList := map[string]struct{}{
+		"key_1": struct{}{},
+		"key_2": struct{}{},
+		"key_3": struct{}{},
+		"key_4": struct{}{},
+	}
+
+	tests := []struct {
+		key      string
+		expected bool
+	}{
+		{"key_1", true},
+		{"key_2", true},
+		{"key_3", true},
+		{"key_4", true},
+		{"not_key", false},
+		{"foo", false},
+		{"bar", false},
+		{"_key_1", false},
+		{"key_1_", false},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		df := dataField{
+			omitList: omitList,
+		}
+		assert.Equal(tt.expected, df.isOmit(tt.key), target)
+	}
+}
+
+func TestGetLogger(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		key         string
+		value       interface{}
+		expected    bool
+		description string
+	}{
+		{"logger", "test_logger", true, "valid logger"},
+		{"logger", "", true, "valid logger"},
+		{"not_logger", "test_logger", false, "invalid key"},
+		{"logger", 1, false, "invalid value type"},
+		{"logger", true, false, "invalid value type"},
+		{"logger", struct{}{}, false, "invalid value type"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		fields[tt.key] = tt.value
+
+		df := newDataField(fields)
+		logger, ok := df.getLogger()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.Equal(tt.value, logger, target)
+		}
+	}
+}
+
+func TestGetServerName(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		key         string
+		value       interface{}
+		expected    bool
+		description string
+	}{
+		{"server_name", "test_server_name", true, "valid server name"},
+		{"server_name", "", true, "valid server name"},
+		{"not_server_name", "test_server_name", false, "invalid key"},
+		{"server_name", 1, false, "invalid value type"},
+		{"server_name", true, false, "invalid value type"},
+		{"server_name", struct{}{}, false, "invalid value type"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		fields[tt.key] = tt.value
+
+		df := newDataField(fields)
+		serverName, ok := df.getServerName()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.Equal(tt.value, serverName, target)
+		}
+	}
+}
+
+func TestGetTags(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		key         string
+		value       interface{}
+		expected    bool
+		description string
+	}{
+		{"tags", raven.Tags{{Key: "key", Value: "value"}}, true, "valid tags"},
+		{"tags", raven.Tags{}, true, "valid tags"},
+		{"not_tags", raven.Tags{{Key: "key", Value: "value"}}, false, "invalid key"},
+		{"tags", "test_tags", false, "invalid value type"},
+		{"tags", 1, false, "invalid value type"},
+		{"tags", true, false, "invalid value type"},
+		{"tags", struct{}{}, false, "invalid value type"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		fields[tt.key] = tt.value
+
+		df := newDataField(fields)
+		tags, ok := df.getTags()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.Equal(tt.value, tags, target)
+		}
+	}
+}
+
+func TestGetError(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		key         string
+		value       interface{}
+		expected    bool
+		description string
+	}{
+		{"error", errors.New("error type"), true, "valid error"},
+		{"error", errors.New(""), true, "valid error"},
+		{"not_error", errors.New("error type"), false, "invalid key"},
+		{"error", "test_error", false, "invalid value type"},
+		{"error", 1, false, "invalid value type"},
+		{"error", true, false, "invalid value type"},
+		{"error", struct{}{}, false, "invalid value type"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		fields[tt.key] = tt.value
+
+		df := newDataField(fields)
+		err, ok := df.getError()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.Equal(tt.value, err, target)
+		}
+	}
+}
+
+func TestGetHTTPRequest(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		key         string
+		value       interface{}
+		expected    bool
+		description string
+	}{
+		{"http_request", &http.Request{}, true, "valid http_request"},
+		{"not_http_request", &http.Request{}, false, "invalid key"},
+		{"http_request", http.Request{}, false, "invalid value type"},
+		{"http_request", "test_http_request", false, "invalid value type"},
+		{"http_request", 1, false, "invalid value type"},
+		{"http_request", true, false, "invalid value type"},
+		{"http_request", struct{}{}, false, "invalid value type"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		fields[tt.key] = tt.value
+
+		df := newDataField(fields)
+		req, ok := df.getHTTPRequest()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.Equal(tt.value, req, target)
+		}
+	}
+}
+
+func TestGetEventID(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		key         string
+		value       interface{}
+		expected    bool
+		description string
+	}{
+		{"event_id", "ffffffff-ffff-ffff-ffff-ffffffffffff", true, "valid event id"},
+		{"event_id", "ffffffffffffffffffffffffffffffff", true, "valid event id"},
+		{"event_id", "urn:uuid:ffffffff-ffff-ffff-ffff-ffffffffffff", true, "valid event id"},
+		{"not_event_id", "ffffffff-ffff-ffff-ffff-ffffffffffff", false, "invalid key"},
+		{"event_id", "test_event_id", false, "invalid uuid format"},
+		{"event_id", "ffffffff-ffff-ffff-ffff-ffffffffffffZ", false, "invalid uuid format"},
+		{"event_id", "Zffffffff-ffff-ffff-ffff-ffffffffffff", false, "invalid uuid format"},
+		{"event_id", 1, false, "invalid value type"},
+		{"event_id", true, false, "invalid value type"},
+		{"event_id", struct{}{}, false, "invalid value type"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		fields[tt.key] = tt.value
+
+		df := newDataField(fields)
+		eventID, ok := df.getEventID()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.Equal("ffffffffffffffffffffffffffffffff", eventID, target)
+		}
+	}
+}
+
+func TestGetUser(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		key         string
+		value       interface{}
+		expected    bool
+		description string
+	}{
+		{"user", &raven.User{}, true, "valid user"},
+		{"user", raven.User{}, true, "valid user"},
+		{"not_user", &raven.User{}, false, "invalid key"},
+		{"user", "test_user", false, "invalid value type"},
+		{"user", 1, false, "invalid value type"},
+		{"user", true, false, "invalid value type"},
+		{"user", struct{}{}, false, "invalid value type"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		fields[tt.key] = tt.value
+
+		df := newDataField(fields)
+		user, ok := df.getUser()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.IsType(&raven.User{}, user, target)
+		}
+	}
+}
+
+func TestGetUserFromString(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		data        map[string]interface{}
+		expected    bool
+		description string
+	}{
+		{map[string]interface{}{
+			"user_name":  "name",
+			"user_email": "example@example.com",
+			"user_id":    "A0001",
+			"user_ip":    "0.0.0.0",
+		}, true, "valid user"},
+		{map[string]interface{}{"user_name": "name"}, true, "valid user"},
+		{map[string]interface{}{"user_email": "example@example.com"}, true, "valid user"},
+		{map[string]interface{}{"user_id": "A0001"}, true, "valid user"},
+		{map[string]interface{}{"user_ip": "0.0.0.0"}, true, "valid user"},
+		{map[string]interface{}{"user_name": ""}, false, "invalid user: empty user_name"},
+		{map[string]interface{}{"user_email": ""}, false, "invalid user: empty user_email"},
+		{map[string]interface{}{"user_id": ""}, false, "invalid user: empty user_id"},
+		{map[string]interface{}{"user_ip": ""}, false, "invalid user: empty user_ip"},
+		{map[string]interface{}{
+			"user_name":  1,
+			"user_email": true,
+			"user_id":    errors.New("user_id"),
+			"user_ip":    "",
+		}, false, "invalid types"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields(tt.data)
+
+		df := newDataField(fields)
+		user, ok := df.getUser()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.IsType(&raven.User{}, user, target)
+		}
+	}
+}

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -375,7 +375,8 @@ func TestFormatExtraData(t *testing.T) {
 			"order":         13,
 			tt.key:          tt.value,
 		}
-		result := hook.formatExtraData(fields)
+		df := newDataField(fields)
+		result := hook.formatExtraData(df)
 
 		value, ok := result[tt.key]
 		if !tt.isExist {


### PR DESCRIPTION
Resolve: #20 

Instead directly delete key from `logrus.Data`, use wrapper struct `dataField` and `omitList` to exclude it from extra data.