### PR TITLE
Add support for asynchronous logging

### DIFF
--- a/async_test.go
+++ b/async_test.go
@@ -1,0 +1,70 @@
+package logrus_sentry
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func TestParallelLogging(t *testing.T) {
+	WithTestDSN(t, func(dsn string, pch <-chan *resultPacket) {
+		logger := getTestLogger()
+
+		hook, err := NewAsyncSentryHook(dsn, []logrus.Level{
+			logrus.ErrorLevel,
+		})
+
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		logger.Hooks.Add(hook)
+
+		wg := &sync.WaitGroup{}
+
+		// start draining messages
+		var logsReceived int
+		const logCount = 10
+		go func() {
+			for i := 0; i < logCount; i++ {
+				timeoutCh := time.After(hook.Timeout * 2)
+				var packet *resultPacket
+				select {
+				case packet = <-pch:
+				case <-timeoutCh:
+					t.Fatalf("Waited %s without a response", hook.Timeout*2)
+				}
+				if packet.Logger != logger_name {
+					t.Errorf("logger should have been %s, was %s", logger_name, packet.Logger)
+				}
+
+				if packet.ServerName != server_name {
+					t.Errorf("server_name should have been %s, was %s", server_name, packet.ServerName)
+				}
+				logsReceived++
+				wg.Done()
+			}
+		}()
+
+		req, _ := http.NewRequest("GET", "url", nil)
+		log := logger.WithFields(logrus.Fields{
+			"server_name":  server_name,
+			"logger":       logger_name,
+			"http_request": req,
+		})
+
+		for i := 0; i < logCount; i++ {
+			wg.Add(1)
+			go func() {
+				log.Error(message)
+			}()
+		}
+
+		wg.Wait()
+		if logCount != logsReceived {
+			t.Errorf("Sent %d logs, received %d", logCount, logsReceived)
+		}
+	})
+}

--- a/sentry.go
+++ b/sentry.go
@@ -198,6 +198,10 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 		}
 	}
 
+	return hook.sendPacket(packet)
+}
+
+func (hook *SentryHook) sendPacket(packet *raven.Packet) error {
 	_, errCh := hook.client.Capture(packet, nil)
 	timeout := hook.Timeout
 	if timeout != 0 {

--- a/sentry.go
+++ b/sentry.go
@@ -35,6 +35,8 @@ type SentryHook struct {
 
 	ignoreFields map[string]struct{}
 	extraFilters map[string]func(interface{}) interface{}
+
+	asynchronous bool
 }
 
 // The Stacktracer interface allows an error type to return a raven.Stacktrace.
@@ -105,6 +107,35 @@ func NewWithClientSentryHook(client *raven.Client, levels []logrus.Level) (*Sent
 		ignoreFields: make(map[string]struct{}),
 		extraFilters: make(map[string]func(interface{}) interface{}),
 	}, nil
+}
+
+// NewAsyncSentryHook creates a hook same as NewSentryHook, but in asynchronous
+// mode.
+func NewAsyncSentryHook(DSN string, levels []logrus.Level) (*SentryHook, error) {
+	hook, err := NewSentryHook(DSN, levels)
+	return setAsync(hook), err
+}
+
+// NewAsyncWithTagsSentryHook creates a hook same as NewWithTagsSentryHook, but
+// in asynchronous mode.
+func NewAsyncWithTagsSentryHook(DSN string, tags map[string]string, levels []logrus.Level) (*SentryHook, error) {
+	hook, err := NewWithTagsSentryHook(DSN, tags, levels)
+	return setAsync(hook), err
+}
+
+// NewAsyncWithClientSentryHook creates a hook same as NewWithClientSentryHook,
+// but in asynchronous mode.
+func NewAsyncWithClientSentryHook(client *raven.Client, levels []logrus.Level) (*SentryHook, error) {
+	hook, err := NewWithClientSentryHook(client, levels)
+	return setAsync(hook), err
+}
+
+func setAsync(hook *SentryHook) *SentryHook {
+	if hook == nil {
+		return nil
+	}
+	hook.asynchronous = true
+	return hook
 }
 
 // Fire is called when an event should be sent to sentry

--- a/sentry.go
+++ b/sentry.go
@@ -110,21 +110,21 @@ func NewWithClientSentryHook(client *raven.Client, levels []logrus.Level) (*Sent
 }
 
 // NewAsyncSentryHook creates a hook same as NewSentryHook, but in asynchronous
-// mode.
+// mode. This method sets the timeout to 1000 milliseconds.
 func NewAsyncSentryHook(DSN string, levels []logrus.Level) (*SentryHook, error) {
 	hook, err := NewSentryHook(DSN, levels)
 	return setAsync(hook), err
 }
 
 // NewAsyncWithTagsSentryHook creates a hook same as NewWithTagsSentryHook, but
-// in asynchronous mode.
+// in asynchronous mode. This method sets the timeout to 1000 milliseconds.
 func NewAsyncWithTagsSentryHook(DSN string, tags map[string]string, levels []logrus.Level) (*SentryHook, error) {
 	hook, err := NewWithTagsSentryHook(DSN, tags, levels)
 	return setAsync(hook), err
 }
 
 // NewAsyncWithClientSentryHook creates a hook same as NewWithClientSentryHook,
-// but in asynchronous mode.
+// but in asynchronous mode. This method sets the timeout to 1000 milliseconds.
 func NewAsyncWithClientSentryHook(client *raven.Client, levels []logrus.Level) (*SentryHook, error) {
 	hook, err := NewWithClientSentryHook(client, levels)
 	return setAsync(hook), err
@@ -134,6 +134,7 @@ func setAsync(hook *SentryHook) *SentryHook {
 	if hook == nil {
 		return nil
 	}
+	hook.Timeout = 1 * time.Second
 	hook.asynchronous = true
 	return hook
 }

--- a/sentry.go
+++ b/sentry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -22,6 +23,11 @@ var (
 	}
 )
 
+// BufSize controls the number of logs that can be in progress before logging
+// will start blocking. Set logrus_sentry.BufSize = <value> _before_ calling
+// NewAsync*().
+var BufSize uint = 8192
+
 // SentryHook delivers logs to a sentry server.
 type SentryHook struct {
 	// Timeout sets the time to wait for a delivery error from the sentry server.
@@ -37,6 +43,8 @@ type SentryHook struct {
 	extraFilters map[string]func(interface{}) interface{}
 
 	asynchronous bool
+	buf          chan *raven.Packet
+	wg           sync.WaitGroup
 }
 
 // The Stacktracer interface allows an error type to return a raven.Stacktrace.
@@ -136,6 +144,8 @@ func setAsync(hook *SentryHook) *SentryHook {
 	}
 	hook.Timeout = 1 * time.Second
 	hook.asynchronous = true
+	hook.buf = make(chan *raven.Packet, BufSize)
+	go hook.fire() // Log in background
 	return hook
 }
 
@@ -199,7 +209,22 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 		}
 	}
 
+	if hook.asynchronous {
+		hook.wg.Add(1)
+		hook.buf <- packet
+		return nil
+	}
 	return hook.sendPacket(packet)
+}
+
+func (hook *SentryHook) fire() {
+	for {
+		packet := <-hook.buf
+		if err := hook.sendPacket(packet); err != nil {
+			fmt.Println(err)
+		}
+		hook.wg.Done()
+	}
 }
 
 func (hook *SentryHook) sendPacket(packet *raven.Packet) error {


### PR DESCRIPTION
This adds support for asynchronous logging, so that log attempts are not blocking.  Further (and most important), this adds a `Flush()` method, which can be used to ensure that any queued log messages are sent.

This functionality is heavily influenced by the async operation of the [logrus-graylog](https://godoc.org/gopkg.in/gemnasium/logrus-graylog-hook.v2) plugin.

Without this functionality, there is no way to ensure that all logs have been sent when the program exits, possibly leading to the final log(s) being lost when a program exits or crashes.