### PR TITLE
A small bugfix to create valid stacktraces

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -292,7 +292,10 @@ func (hook *SentryHook) convertStackTrace(st errors.StackTrace) *raven.Stacktrac
 		pc := uintptr(stFrames[i])
 		fn := runtime.FuncForPC(pc)
 		file, line := fn.FileLine(pc)
-		frames = append(frames, raven.NewStacktraceFrame(pc, file, line, stConfig.Context, stConfig.InAppPrefixes))
+		frame := raven.NewStacktraceFrame(pc, file, line, stConfig.Context, stConfig.InAppPrefixes)
+		if frame != nil {
+			frames = append(frames, frame)
+		}
 	}
 	return &raven.Stacktrace{Frames: frames}
 }

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -264,7 +264,7 @@ func TestSentryStacktrace(t *testing.T) {
 			frames = packet.Exception.Stacktrace.Frames
 		}
 		expectedPkgErrorsStackTraceFilename := "github.com/evalphobia/logrus_sentry/sentry_test.go"
-		expectedFrameCount := 5
+		expectedFrameCount := 4
 		expectedCulprit = "errorX"
 		if packet.Culprit != expectedCulprit {
 			t.Errorf("Expected culprit of '%s', got '%s'", expectedCulprit, packet.Culprit)


### PR DESCRIPTION
raven.NewStacktraceFrame() ignores frames for `runtime.goexit`, which lead to occasional null values in stack traces generated from `github.com/pkg/errors` stacktraces, which sentry doesn't like.  This fixes the oversight.