### PR TITLE
Fix ordering of stack traces taken from pkg/errors

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -189,7 +189,8 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 	if stConfig.Enable && entry.Level <= stConfig.Level {
 		if err, ok := df.getError(); ok {
 			var currentStacktrace *raven.Stacktrace
-			currentStacktrace, err = hook.findStacktraceAndCause(err)
+			err := errors.Cause(err)
+			currentStacktrace = hook.findStacktrace(err)
 			if currentStacktrace == nil {
 				currentStacktrace = raven.NewStacktrace(stConfig.Skip, stConfig.Context, stConfig.InAppPrefixes)
 			}
@@ -257,8 +258,7 @@ func (hook *SentryHook) sendPacket(packet *raven.Packet) error {
 	return nil
 }
 
-func (hook *SentryHook) findStacktraceAndCause(err error) (*raven.Stacktrace, error) {
-	errCause := errors.Cause(err)
+func (hook *SentryHook) findStacktrace(err error) *raven.Stacktrace {
 	var stacktrace *raven.Stacktrace
 	var stackErr errors.StackTrace
 	for err != nil {
@@ -279,7 +279,7 @@ func (hook *SentryHook) findStacktraceAndCause(err error) (*raven.Stacktrace, er
 	if stackErr != nil {
 		stacktrace = hook.convertStackTrace(stackErr)
 	}
-	return stacktrace, errCause
+	return stacktrace
 }
 
 // convertStackTrace converts an errors.StackTrace into a natively consumable

--- a/sentry.go
+++ b/sentry.go
@@ -297,6 +297,11 @@ func (hook *SentryHook) convertStackTrace(st errors.StackTrace) *raven.Stacktrac
 			frames = append(frames, frame)
 		}
 	}
+
+	// Sentry wants the frames with the oldest first, so reverse them
+	for i, j := 0, len(frames)-1; i < j; i, j = i+1, j-1 {
+		frames[i], frames[j] = frames[j], frames[i]
+	}
 	return &raven.Stacktrace{Frames: frames}
 }
 

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -263,7 +263,7 @@ func TestSentryStacktrace(t *testing.T) {
 		if packet.Exception.Stacktrace != nil {
 			frames = packet.Exception.Stacktrace.Frames
 		}
-		expectedPkgErrorsStackTraceFilename := "github.com/evalphobia/logrus_sentry/sentry_test.go"
+		expectedPkgErrorsStackTraceFilename := "testing/testing.go"
 		expectedFrameCount := 4
 		expectedCulprit = "errorX"
 		if packet.Culprit != expectedCulprit {

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -450,3 +450,18 @@ func (myStacktracerError) GetStacktrace() *raven.Stacktrace {
 		},
 	}
 }
+
+func TestConvertStackTrace(t *testing.T) {
+	hook := SentryHook{}
+	expected := raven.NewStacktrace(0, 0, nil)
+	st := pkgerrors.New("-").(pkgErrorStackTracer).StackTrace()
+	ravenSt := hook.convertStackTrace(st)
+
+	// Obscure the line numbes, so DeepEqual doesn't fail erroneously
+	for _, frame := range append(expected.Frames, ravenSt.Frames...) {
+		frame.Lineno = 999
+	}
+	if !reflect.DeepEqual(ravenSt, expected) {
+		t.Error("stack traces differ")
+	}
+}

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -272,7 +272,7 @@ func TestSentryStacktrace(t *testing.T) {
 		if len(frames) != expectedFrameCount {
 			t.Errorf("Expected %d frames, got %d", expectedFrameCount, len(frames))
 		}
-		if frames[0].Filename != expectedPkgErrorsStackTraceFilename {
+		if !strings.HasSuffix(frames[0].Filename, expectedPkgErrorsStackTraceFilename) {
 			t.Error("Stacktrace should be taken from err if it implements the pkgErrorStackTracer interface")
 		}
 	})


### PR DESCRIPTION
Please accept my apologies for the _second_ bug in my original PR.  We're all pretty new to sentry and logrus here on this project... :)

Sentry expects stack traces to be in reverse order from that generated by Go by default. This corrects the order.