### PR TITLE
Allow *revel.Http structs in `http_request` field

### DIFF
--- a/data_field.go
+++ b/data_field.go
@@ -69,10 +69,10 @@ func (d *dataField) getError() (error, bool) {
 	return nil, false
 }
 
-func (d *dataField) getHTTPRequest() (*http.Request, bool) {
+func (d *dataField) getHTTPRequest() (*raven.Http, bool) {
 	if req, ok := d.data[fieldHTTPRequest].(*http.Request); ok {
 		d.omitList[fieldHTTPRequest] = struct{}{}
-		return req, true
+		return raven.NewHttp(req), true
 	}
 	return nil, false
 }

--- a/data_field.go
+++ b/data_field.go
@@ -74,6 +74,10 @@ func (d *dataField) getHTTPRequest() (*raven.Http, bool) {
 		d.omitList[fieldHTTPRequest] = struct{}{}
 		return raven.NewHttp(req), true
 	}
+	if req, ok := d.data[fieldHTTPRequest].(*raven.Http); ok {
+		d.omitList[fieldHTTPRequest] = struct{}{}
+		return req, true
+	}
 	return nil, false
 }
 

--- a/data_field_test.go
+++ b/data_field_test.go
@@ -221,14 +221,17 @@ func TestGetError(t *testing.T) {
 func TestGetHTTPRequest(t *testing.T) {
 	assert := assert.New(t)
 
+	httpReq, _ := http.NewRequest("GET", "/", nil)
+	ravenReq := raven.NewHttp(httpReq)
+
 	tests := []struct {
 		key         string
 		value       interface{}
 		expected    bool
 		description string
 	}{
-		{"http_request", &http.Request{}, true, "valid http_request"},
-		{"not_http_request", &http.Request{}, false, "invalid key"},
+		{"http_request", httpReq, true, "valid http_request"},
+		{"not_http_request", httpReq, false, "invalid key"},
 		{"http_request", http.Request{}, false, "invalid value type"},
 		{"http_request", "test_http_request", false, "invalid value type"},
 		{"http_request", 1, false, "invalid value type"},
@@ -246,7 +249,7 @@ func TestGetHTTPRequest(t *testing.T) {
 		req, ok := df.getHTTPRequest()
 		assert.Equal(tt.expected, ok, target)
 		if ok {
-			assert.Equal(tt.value, req, target)
+			assert.Equal(ravenReq, req, target)
 			assert.True(df.isOmit("http_request"), "`http_request` should be in omitList")
 		} else {
 			assert.False(df.isOmit("http_request"), "`http_request` should not be in omitList")

--- a/data_field_test.go
+++ b/data_field_test.go
@@ -237,6 +237,8 @@ func TestGetHTTPRequest(t *testing.T) {
 		{"http_request", 1, false, "invalid value type"},
 		{"http_request", true, false, "invalid value type"},
 		{"http_request", struct{}{}, false, "invalid value type"},
+		{"http_request", raven.NewHttp(httpReq), true, "valid raven http_request"},
+		{"http_request", raven.Http{}, false, "invalid raven http_request"},
 	}
 
 	for _, tt := range tests {

--- a/sentry.go
+++ b/sentry.go
@@ -178,7 +178,7 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 		packet.Tags = tags
 	}
 	if req, ok := df.getHTTPRequest(); ok {
-		packet.Interfaces = append(packet.Interfaces, raven.NewHttp(req))
+		packet.Interfaces = append(packet.Interfaces, req)
 	}
 	if user, ok := df.getUser(); ok {
 		packet.Interfaces = append(packet.Interfaces, user)


### PR DESCRIPTION
Fixes #30 