### PR TITLE
Fix default stracktrace being reported if the root Cause doesn't implement the stacktrace interfaces

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -189,11 +189,11 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 	if stConfig.Enable && entry.Level <= stConfig.Level {
 		if err, ok := df.getError(); ok {
 			var currentStacktrace *raven.Stacktrace
-			err := errors.Cause(err)
 			currentStacktrace = hook.findStacktrace(err)
 			if currentStacktrace == nil {
 				currentStacktrace = raven.NewStacktrace(stConfig.Skip, stConfig.Context, stConfig.InAppPrefixes)
 			}
+			err := errors.Cause(err)
 			exc := raven.NewException(err, currentStacktrace)
 			packet.Interfaces = append(packet.Interfaces, exc)
 			packet.Culprit = err.Error()


### PR DESCRIPTION
This fixes a bug where stack traces which are attached to errors will be ignored.

`findStackTrace` is meant to look through the entire chain of errors (via the `Causer` interface), searching for the last stack trace in the chain (which should correspond to the point that's closest to the origin of the error). But because `err := errors.Cause(err)` has already been performed, the error that's passed to `findStackTrace` will always be the last error in the chain, and that error might not be the one that provides the stack trace. E.g. if you use `errors.Wrap()` to wrap a JSON unmarshal error then the stacktrace won't be found. The code will then fall back to generating a new stack trace (corresponding to the call to the log function), potentially losing important context about the true location of the error.