### PR TITLE
Support fingerprinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,9 @@ Some logrus fields have a special meaning in this hook, and they will be especia
 | `user_ip`  | IP of the user who is in the context of the event |
 | `server_name`  | Also known as hostname, it is the name of the server which is logging the event (hostname.example.com)  |
 | `tags`  | `tags` are `raven.Tags` struct from `github.com/getsentry/raven-go` and override default tags data |
+| `fingerprint`  | `fingerprint` is an string array, that allows you to affect sentry's grouping of events as detailed in the [sentry documentation](https://docs.sentry.io/learn/rollups/#customize-grouping-with-fingerprints) |
 | `logger`  | `logger` is the part of the application which is logging the event. In go this usually means setting it to the name of the package. |
 | `http_request`  | `http_request` is the in-coming request(*http.Request). The detailed request data are sent to Sentry. |
-
-
 
 ## Timeout
 

--- a/data_field.go
+++ b/data_field.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	fieldEventID     = "event_id"
+	fieldFingerprint = "fingerprint"
 	fieldLogger      = "logger"
 	fieldServerName  = "server_name"
 	fieldTags        = "tags"
@@ -57,6 +58,14 @@ func (d *dataField) getTags() (raven.Tags, bool) {
 	if tags, ok := d.data[fieldTags].(raven.Tags); ok {
 		d.omitList[fieldTags] = struct{}{}
 		return tags, true
+	}
+	return nil, false
+}
+
+func (d *dataField) getFingerprint() ([]string, bool) {
+	if fingerprint, ok := d.data[fieldFingerprint].([]string); ok {
+		d.omitList[fieldFingerprint] = struct{}{}
+		return fingerprint, true
 	}
 	return nil, false
 }

--- a/data_field_test.go
+++ b/data_field_test.go
@@ -18,7 +18,7 @@ func TestLen(t *testing.T) {
 	tests := []struct {
 		fieldSize int
 	}{
-		{0},   // empty fileds
+		{0},   // empty fields
 		{1},   // "0"
 		{2},   // "0", "1"
 		{9},   // "0", "1", "2" ... "8"
@@ -178,6 +178,43 @@ func TestGetTags(t *testing.T) {
 			assert.True(df.isOmit("tags"), "`tags` should be in omitList")
 		} else {
 			assert.False(df.isOmit("tags"), "`tags` should not be in omitList")
+		}
+	}
+}
+
+func TestGetFingerprint(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		key         string
+		value       interface{}
+		expected    bool
+		description string
+	}{
+		{"fingerprint", []string{"a", "fingerprint"}, true, "valid fingerprint"},
+		{"fingerprint", []string{}, true, "valid fingerprint"},
+		{"not_fingerprint", []string{"a", "fingerprint"}, false, "invalid key"},
+		{"fingerprint", []int{}, false, "invalid value type"},
+		{"fingerprint", "test_fingerprint", false, "invalid value type"},
+		{"fingerprint", 1, false, "invalid value type"},
+		{"fingerprint", true, false, "invalid value type"},
+		{"fingerprint", struct{}{}, false, "invalid value type"},
+	}
+
+	for _, tt := range tests {
+		target := fmt.Sprintf("%+v", tt)
+
+		fields := logrus.Fields{}
+		fields[tt.key] = tt.value
+
+		df := newDataField(fields)
+		fingerprint, ok := df.getFingerprint()
+		assert.Equal(tt.expected, ok, target)
+		if ok {
+			assert.Equal(tt.value, fingerprint, target)
+			assert.True(df.isOmit("fingerprint"), "`fingerprint` should be in omitList")
+		} else {
+			assert.False(df.isOmit("fingerprint"), "`fingerprint` should not be in omitList")
 		}
 	}
 }

--- a/sentry.go
+++ b/sentry.go
@@ -177,6 +177,9 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 	if tags, ok := df.getTags(); ok {
 		packet.Tags = tags
 	}
+	if fingerprint, ok := df.getFingerprint(); ok {
+		packet.Fingerprint = fingerprint
+	}
 	if req, ok := df.getHTTPRequest(); ok {
 		packet.Interfaces = append(packet.Interfaces, req)
 	}

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -222,8 +222,7 @@ func TestSentryStacktrace(t *testing.T) {
 		hook.StacktraceConfiguration.Enable = true
 
 		logger.Error(message) // this is the call that the last frame of stacktrace should capture
-		expectedLineno := 199 //this should be the line number of the previous line
-
+		expectedLineno := 224 //this should be the line number of the previous line
 		packet = <-pch
 		stacktraceSize = len(packet.Stacktrace.Frames)
 		if stacktraceSize == 0 {

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -170,7 +170,32 @@ func TestSentryTags(t *testing.T) {
 			},
 		}
 		if !reflect.DeepEqual(packet.Tags, expected) {
-			t.Errorf("message should have been %s, was %s", message, packet.Message)
+			t.Errorf("tags should have been %+v, was %+v", expected, packet.Tags)
+		}
+	})
+}
+
+func TestSentryFingerprint(t *testing.T) {
+	WithTestDSN(t, func(dsn string, pch <-chan *resultPacket) {
+		logger := getTestLogger()
+		levels := []logrus.Level{
+			logrus.ErrorLevel,
+		}
+		fingerprint := []string{"fingerprint"}
+
+		hook, err := NewSentryHook(dsn, levels)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		logger.Hooks.Add(hook)
+
+		logger.WithFields(logrus.Fields{
+			"fingerprint": fingerprint,
+		}).Error(message)
+		packet := <-pch
+		if !reflect.DeepEqual(packet.Fingerprint, fingerprint) {
+			t.Errorf("fingerprint should have been %v, was %v", fingerprint, packet.Fingerprint)
 		}
 	})
 }


### PR DESCRIPTION
Sentry uses an array of strings as a fingerprint. This allows to group messages that otherwise wouldn't be grouped.