### PR TITLE
Stacktrace the culprit should be the received error not the cause

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -197,8 +197,7 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 			if currentStacktrace == nil {
 				currentStacktrace = raven.NewStacktrace(stConfig.Skip, stConfig.Context, stConfig.InAppPrefixes)
 			}
-			err := errors.Cause(err)
-			exc := raven.NewException(err, currentStacktrace)
+			exc := raven.NewException(errors.Cause(err), currentStacktrace)
 			if !stConfig.SendExceptionType {
 				exc.Type = ""
 			}

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -300,7 +300,7 @@ func TestSentryStacktrace(t *testing.T) {
 		if packet.Exception.Stacktrace != nil {
 			frames = packet.Exception.Stacktrace.Frames
 		}
-		expectedCulprit := "myStacktracerError!"
+		expectedCulprit := "wrapped: myStacktracerError!"
 		if packet.Culprit != expectedCulprit {
 			t.Errorf("Expected culprit of '%s', got '%s'", expectedCulprit, packet.Culprit)
 		}


### PR DESCRIPTION
Previously, when stacktrace was enabled, the culprit would be set to
the first error that did not implement Cause (as detected by `errors.Cause(err)`),
this had the affect of not showing any additional context added to
the error.

This was also inconsistent with the same behaviour when stacktrace was
disabled.

This change attempts to unify that behaviour, as well as to not discard
the context added to the errors.

Example program (snippet):

```go
// url is being set to https://www.google.com.au
func (p *Poller) Poll(ctx context.Context, url string) {
        ticker := time.NewTicker(time.Second)
        defer ticker.Stop()

        for {
                select {
                case <-ctx.Done():
                        return
                case <-ticker.C:
                        err := poll(ctx, url)
                        if err != nil {
                                p.logger.WithError(err).Error("could not poll url")
                        }
                }
        }
}

func poll(ctx context.Context, url string) error {
        err := io.EOF
        return errors.Wrapf(err, "could not poll %v", url)
}
```

Current behaviour with Stacktrace enabled (notice no `could not poll %v` - we've lost the context):

![screen shot 2017-04-21 at 3 36 29 pm](https://cloud.githubusercontent.com/assets/1834577/25265129/8fbc00c2-26aa-11e7-8e20-97bc8ee0bbb4.png)

Current behaviour without Stacktrace enabled (we have our context):

![screen shot 2017-04-21 at 3 39 17 pm](https://cloud.githubusercontent.com/assets/1834577/25265185/e0b1eaaa-26aa-11e7-964a-0aa0d9ec693d.png)

Proposed behaviour (but this still doesn't unify the behaviour with or without stack trace):

![screen shot 2017-04-21 at 3 40 38 pm](https://cloud.githubusercontent.com/assets/1834577/25265214/19239096-26ab-11e7-815e-29b0e851e610.png)

Alternative (by removing `err := errors.Cause(err)` completely):

![screen shot 2017-04-21 at 3 42 35 pm](https://cloud.githubusercontent.com/assets/1834577/25265235/35fa14d8-26ab-11e7-8ba3-813f684e4836.png)

So, I'm happier with the proposed behaviour, as I now have the context around the error again, but it's still not the same as the behaviour with or without stacktrace being enabled. Thoughts, do they need to be the same? Does this break Sentry's ability to group errors if the context changes slightly but the root cause is the same?