### PR TITLE
Update import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Every sentry application defined on the server gets a different
 
 ```go
 import (
-  "github.com/Sirupsen/logrus"
+  "github.com/sirupsen/logrus"
   "github.com/evalphobia/logrus_sentry"
 )
 
@@ -54,7 +54,7 @@ the `NewWithClientSentryHook` constructor:
 
 ```go
 import (
-  "github.com/Sirupsen/logrus"
+  "github.com/sirupsen/logrus"
   "github.com/evalphobia/logrus_sentry"
   "github.com/getsentry/raven-go"
 )

--- a/async_test.go
+++ b/async_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func TestParallelLogging(t *testing.T) {

--- a/data_field.go
+++ b/data_field.go
@@ -3,8 +3,8 @@ package logrus_sentry
 import (
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/getsentry/raven-go"
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/data_field_test.go
+++ b/data_field_test.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/getsentry/raven-go"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/sentry.go
+++ b/sentry.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/getsentry/raven-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/getsentry/raven-go"
 	pkgerrors "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -266,7 +266,7 @@ func TestSentryStacktrace(t *testing.T) {
 			t.Error("Frame should not be identified as in_app without prefixes")
 		}
 
-		hook.StacktraceConfiguration.InAppPrefixes = []string{"github.com/Sirupsen/logrus"}
+		hook.StacktraceConfiguration.InAppPrefixes = []string{"github.com/sirupsen/logrus"}
 		hook.StacktraceConfiguration.Context = 2
 		hook.StacktraceConfiguration.Skip = 2
 
@@ -277,7 +277,7 @@ func TestSentryStacktrace(t *testing.T) {
 			t.Error("Stacktrace should not be empty")
 		}
 		lastFrame = packet.Stacktrace.Frames[stacktraceSize-1]
-		expectedFilename := "github.com/Sirupsen/logrus/entry.go"
+		expectedFilename := "github.com/sirupsen/logrus/entry.go"
 		if lastFrame.Filename != expectedFilename {
 			t.Errorf("File name should have been %s, was %s", expectedFilename, lastFrame.Filename)
 		}


### PR DESCRIPTION
Logrus renamed the uppercase "Sirupsen" to "Sirupsen":
https://github.com/sirupsen/logrus/pull/384

Several libraries that integrate with Logrus are using the new lowercase import
path, for example the graylog hook:
https://github.com/gemnasium/logrus-graylog-hook/commit/daf02e0efe6f4dee3f7085184f5d527cf5cf0f6b