### PR TITLE
Rename sirupsen to Sirupsen

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Every sentry application defined on the server gets a different
 
 ```go
 import (
-  "github.com/sirupsen/logrus"
+  "github.com/Sirupsen/logrus"
   "github.com/evalphobia/logrus_sentry"
 )
 
@@ -54,7 +54,7 @@ the `NewWithClientSentryHook` constructor:
 
 ```go
 import (
-  "github.com/sirupsen/logrus"
+  "github.com/Sirupsen/logrus"
   "github.com/evalphobia/logrus_sentry"
   "github.com/getsentry/raven-go"
 )

--- a/async_test.go
+++ b/async_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 func TestParallelLogging(t *testing.T) {

--- a/data_field.go
+++ b/data_field.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/getsentry/raven-go"
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 const (

--- a/data_field_test.go
+++ b/data_field_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/getsentry/raven-go"
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/sentry.go
+++ b/sentry.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/getsentry/raven-go"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 var (

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/getsentry/raven-go"
 	pkgerrors "github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -266,7 +266,7 @@ func TestSentryStacktrace(t *testing.T) {
 			t.Error("Frame should not be identified as in_app without prefixes")
 		}
 
-		hook.StacktraceConfiguration.InAppPrefixes = []string{"github.com/sirupsen/logrus"}
+		hook.StacktraceConfiguration.InAppPrefixes = []string{"github.com/Sirupsen/logrus"}
 		hook.StacktraceConfiguration.Context = 2
 		hook.StacktraceConfiguration.Skip = 2
 
@@ -277,7 +277,7 @@ func TestSentryStacktrace(t *testing.T) {
 			t.Error("Stacktrace should not be empty")
 		}
 		lastFrame = packet.Stacktrace.Frames[stacktraceSize-1]
-		expectedFilename := "github.com/sirupsen/logrus/entry.go"
+		expectedFilename := "github.com/Sirupsen/logrus/entry.go"
 		if lastFrame.Filename != expectedFilename {
 			t.Errorf("File name should have been %s, was %s", expectedFilename, lastFrame.Filename)
 		}


### PR DESCRIPTION
There is an issue with this lib when is used together with the `glide` vendoring tool.

If I add `logrus_sentry` as a dependency to the `glide.yml` I will end up with this errors during `glide install`:

```
[INFO]	--> Fetching updates for github.com/sirupsen/logrus.
[ERROR]	Error looking for github.com/sirupsen/logrus: The Remote does not match the VCS endpoint
```

This is because you specify `github.com/sirupsen/logrus` as a dependency instead of `github.com/Sirupsen/logrus`. It breaks only on case-sensitive FS (for example OSX).

Refence: https://github.com/Masterminds/glide/issues/781
