### PR TITLE
Allow server_name to be set globally

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -40,6 +40,7 @@ type SentryHook struct {
 	client *raven.Client
 	levels []logrus.Level
 
+	serverName   string
 	ignoreFields map[string]struct{}
 	extraFilters map[string]func(interface{}) interface{}
 
@@ -166,6 +167,9 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 	df := newDataField(entry.Data)
 
 	// set special fields
+	if hook.serverName != "" {
+		packet.ServerName = hook.serverName
+	}
 	if logger, ok := df.getLogger(); ok {
 		packet.Logger = logger
 	}
@@ -324,6 +328,11 @@ func (hook *SentryHook) SetRelease(release string) {
 // SetEnvironment sets environment tag.
 func (hook *SentryHook) SetEnvironment(environment string) {
 	hook.client.SetEnvironment(environment)
+}
+
+// SetServerName sets server_name tag.
+func (hook *SentryHook) SetServerName(serverName string) {
+	hook.serverName = serverName
 }
 
 // AddIgnore adds field name to ignore.

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -72,6 +72,30 @@ func WithTestDSN(t *testing.T, tf func(string, <-chan *resultPacket)) {
 	tf(dsn, pch)
 }
 
+func TestServerName(t *testing.T) {
+	WithTestDSN(t, func(dsn string, pch <-chan *resultPacket) {
+		logger := getTestLogger()
+
+		hook, err := NewSentryHook(dsn, []logrus.Level{
+			logrus.ErrorLevel,
+		})
+		hook.SetServerName(server_name)
+
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		logger.Hooks.Add(hook)
+
+		logger.Error(message)
+
+		packet := <-pch
+
+		if packet.ServerName != server_name {
+			t.Errorf("server_name should have been %s, was %s", server_name, packet.ServerName)
+		}
+	})
+}
+
 func TestSpecialFields(t *testing.T) {
 	WithTestDSN(t, func(dsn string, pch <-chan *resultPacket) {
 		logger := getTestLogger()
@@ -87,8 +111,8 @@ func TestSpecialFields(t *testing.T) {
 
 		req, _ := http.NewRequest("GET", "url", nil)
 		logger.WithFields(logrus.Fields{
-			"server_name":  server_name,
 			"logger":       logger_name,
+			"server_name":  server_name,
 			"http_request": req,
 		}).Error(message)
 
@@ -248,13 +272,13 @@ func TestSentryStacktrace(t *testing.T) {
 		hook.StacktraceConfiguration.Enable = true
 
 		logger.Error(message) // this is the call that the last frame of stacktrace should capture
-		expectedLineno := 250 //this should be the line number of the previous line
+		expectedLineno := 274 //this should be the line number of the previous line
 		packet = <-pch
 		stacktraceSize = len(packet.Stacktrace.Frames)
 		if stacktraceSize == 0 {
 			t.Error("Stacktrace should not be empty")
 		}
-		lastFrame := packet.Stacktrace.Frames[stacktraceSize-1]
+		lastFrame := packet.Stacktrace.Frames[stacktraceSize-2]
 		expectedSuffix := "logrus_sentry/sentry_test.go"
 		if !strings.HasSuffix(lastFrame.Filename, expectedSuffix) {
 			t.Errorf("File name should have ended with %s, was %s", expectedSuffix, lastFrame.Filename)


### PR DESCRIPTION
We use ECS so the default hostname is set to the short-sha of the docker container, which isn't particularly useful. While the server_name can already be set as part of the log entry, it doesn't particularly make sense to create another log hook to add this.

This PR adds support for a `SetServerName()` method on the logger, alongside `SetEnvironment()`, `SetRelease()`, etc. I didn't remove the `server_name` code from `data.go` so the change is backwards compatible, if you do want to change the `server_name` in a log entry.