### PR TITLE
Allow switching the exception type and message

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -79,7 +79,7 @@ type StackTraceConfiguration struct {
 	InAppPrefixes []string
 	// whether sending exception type should be enabled.
 	SendExceptionType bool
-	// whether sending exception type should be enabled.
+	// whether the exception type and message should be switched.
 	SwitchExceptionTypeAndMessage bool
 }
 

--- a/sentry.go
+++ b/sentry.go
@@ -79,6 +79,8 @@ type StackTraceConfiguration struct {
 	InAppPrefixes []string
 	// whether sending exception type should be enabled.
 	SendExceptionType bool
+	// whether sending exception type should be enabled.
+	SwitchExceptionTypeAndMessage bool
 }
 
 // NewSentryHook creates a hook to be added to an instance of logger
@@ -204,6 +206,9 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 			exc := raven.NewException(errors.Cause(err), currentStacktrace)
 			if !stConfig.SendExceptionType {
 				exc.Type = ""
+			}
+			if stConfig.SwitchExceptionTypeAndMessage {
+				exc.Type, exc.Value = exc.Value, exc.Type
 			}
 			packet.Interfaces = append(packet.Interfaces, exc)
 			packet.Culprit = err.Error()


### PR DESCRIPTION
The exception type in Go can be quite useless. So I would rather have the exception value displayed in the big font in the interface. This adds a config option to switch them.