### PR TITLE
When errors.Cause returns nil, use the original error value instead

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -203,7 +203,11 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 			if currentStacktrace == nil {
 				currentStacktrace = raven.NewStacktrace(stConfig.Skip, stConfig.Context, stConfig.InAppPrefixes)
 			}
-			exc := raven.NewException(errors.Cause(err), currentStacktrace)
+			cause := errors.Cause(err)
+			if cause == nil {
+				cause = err
+			}
+			exc := raven.NewException(cause, currentStacktrace)
 			if !stConfig.SendExceptionType {
 				exc.Type = ""
 			}


### PR DESCRIPTION
When stack trace was enabled, we saw panics on line

	exc := raven.NewException(errors.Cause(err), currentStacktrace)

We believe it is because errors.Cause(err) returns nil, if the
error was created using package github.com/juju/errors, not
github.com/pkg/errors