### PR TITLE
Update to raven-go v0.1.1

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -313,7 +313,7 @@ func (hook *SentryHook) convertStackTrace(st errors.StackTrace) *raven.Stacktrac
 		pc := uintptr(stFrames[i])
 		fn := runtime.FuncForPC(pc)
 		file, line := fn.FileLine(pc)
-		frame := raven.NewStacktraceFrame(pc, file, line, stConfig.Context, stConfig.InAppPrefixes)
+		frame := raven.NewStacktraceFrame(pc, fn.Name(), file, line, stConfig.Context, stConfig.InAppPrefixes)
 		if frame != nil {
 			frames = append(frames, frame)
 		}


### PR DESCRIPTION
This PR adds the function name to NewStackTraceFrame call, this is a new parameters required by https://github.com/getsentry/raven-go and introduced in v0.1.1.