### PR TITLE
Revert to PC after breaking change in pkg/errors was reverted

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -3,6 +3,7 @@ package logrus_sentry
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
@@ -309,9 +310,11 @@ func (hook *SentryHook) convertStackTrace(st errors.StackTrace) *raven.Stacktrac
 	stConfig := &hook.StacktraceConfiguration
 	stFrames := []errors.Frame(st)
 	frames := make([]*raven.StacktraceFrame, 0, len(stFrames))
-	for _, stFrame := range stFrames {
-		frame := raven.NewStacktraceFrame(stFrame.PC, stFrame.Func.Name(), stFrame.File, stFrame.Line,
-			stConfig.Context, stConfig.InAppPrefixes)
+	for i := range stFrames {
+		pc := uintptr(stFrames[i])
+		fn := runtime.FuncForPC(pc)
+		file, line := fn.FileLine(pc)
+		frame := raven.NewStacktraceFrame(pc, fn.Name(), file, line, stConfig.Context, stConfig.InAppPrefixes)
 		if frame != nil {
 			frames = append(frames, frame)
 		}


### PR DESCRIPTION
A more recent [PR](https://github.com/pkg/errors/pull/193) on pkg/errors
reverts usage of runtime.Frame after complaints about [breaking
change](https://github.com/pkg/errors/pull/183).