### PR TITLE
Add option to add error breadcrumb in sentry log

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,4 @@ Other configuration options are:
 - `StacktraceConfiguration.Skip` how many stack frames to skip before stacktrace starts recording.
 - `StacktraceConfiguration.Context` the number of lines to include around a stack frame for context.
 - `StacktraceConfiguration.InAppPrefixes` the prefixes that will be matched against the stack frame to identify it as in_app
+- `StacktraceConfiguration.IncludeErrorBreadcrumb` whether to create a breadcrumb with the full text of error

--- a/sentry.go
+++ b/sentry.go
@@ -83,6 +83,8 @@ type StackTraceConfiguration struct {
 	SendExceptionType bool
 	// whether the exception type and message should be switched.
 	SwitchExceptionTypeAndMessage bool
+	// whether to include a breadcrumb with the full error stack
+	IncludeErrorBreadcrumb bool
 }
 
 // NewSentryHook creates a hook to be added to an instance of logger
@@ -168,16 +170,13 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 
 	err, hasError := df.getError()
 	var crumbs *Breadcrumbs
-	if hasError {
-		_, isCauser := err.(causer)
-		if isCauser {
-			crumbs = &Breadcrumbs{
-				Values: []Value{{
-					Timestamp: int64(time.Now().Unix()),
-					Type:      "error",
-					Message:   fmt.Sprintf("%+v", err),
-				}},
-			}
+	if hasError && hook.StacktraceConfiguration.IncludeErrorBreadcrumb {
+		crumbs = &Breadcrumbs{
+			Values: []Value{{
+				Timestamp: int64(time.Now().Unix()),
+				Type:      "error",
+				Message:   fmt.Sprintf("%+v", err),
+			}},
 		}
 	}
 

--- a/sentry.go
+++ b/sentry.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/getsentry/raven-go"
+	raven "github.com/getsentry/raven-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -163,12 +163,28 @@ func setAsync(hook *SentryHook) *SentryHook {
 func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 	hook.mu.RLock() // Allow multiple go routines to log simultaneously
 	defer hook.mu.RUnlock()
-	packet := raven.NewPacket(entry.Message)
+
+	df := newDataField(entry.Data)
+
+	err, hasError := df.getError()
+	var crumbs *Breadcrumbs
+	if hasError {
+		_, isCauser := err.(causer)
+		if isCauser {
+			crumbs = &Breadcrumbs{
+				Values: []Value{{
+					Timestamp: int64(time.Now().Unix()),
+					Type:      "error",
+					Message:   fmt.Sprintf("%+v", err),
+				}},
+			}
+		}
+	}
+
+	packet := raven.NewPacketWithExtra(entry.Message, nil, crumbs)
 	packet.Timestamp = raven.Timestamp(entry.Time)
 	packet.Level = severityMap[entry.Level]
 	packet.Platform = "go"
-
-	df := newDataField(entry.Data)
 
 	// set special fields
 	if hook.serverName != "" {
@@ -388,4 +404,22 @@ func formatData(value interface{}) (formatted interface{}) {
 	default:
 		return value
 	}
+}
+
+// utility classes for breadcrumb support
+type Breadcrumbs struct {
+	Values []Value `json:"values"`
+}
+
+type Value struct {
+	Timestamp int64       `json:"timestamp"`
+	Type      string      `json:"type"`
+	Message   string      `json:"message"`
+	Category  string      `json:"category"`
+	Level     string      `json:"string"`
+	Data      interface{} `json:"data"`
+}
+
+func (b *Breadcrumbs) Class() string {
+	return "breadcrumbs"
 }


### PR DESCRIPTION
When using `pkg/errors` a problem we keep encountering is that sentry truncates the error message, which removes relevant information that has been annotated on the error via `Wrapf`. I looked into adding this into the StackTraceFrame but it would include a mountain of changes including ones upstream in raven-go.

This instead adds a new option `IncludeErrorBreadcrumb` which when true will add a breadcrumb to the sentry report that includes the verbose print of the error. When using `pkg/errors` this gives you a full trace including the annotations.

Totally understand if this isn't something you want to merge but leaving this here as maybe it will be useful to others. The "right" way to do this is to annotate each StackTraceFrame with `vars` in the cases where there is an annotation. This would require tweaking `pkg/errors` to get at the error message at that level (and not only the recursive error message) and tweaking `getsentry/raven-go` to let us set `vars` on a StackTraceFrame.

![errors fundamental illegal method get 2019-01-29 10-40-58](https://user-images.githubusercontent.com/168067/51931972-01edf180-23b3-11e9-8f07-a1f6074da75b.png)
