### PR TITLE
Fix stacktrace conversion

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -334,7 +334,7 @@ func (hook *SentryHook) convertStackTrace(st errors.StackTrace) *raven.Stacktrac
 	stFrames := []errors.Frame(st)
 	frames := make([]*raven.StacktraceFrame, 0, len(stFrames))
 	for i := range stFrames {
-		pc := uintptr(stFrames[i])
+		pc := uintptr(stFrames[i]) - 1
 		fn := runtime.FuncForPC(pc)
 		file, line := fn.FileLine(pc)
 		frame := raven.NewStacktraceFrame(pc, fn.Name(), file, line, stConfig.Context, stConfig.InAppPrefixes)


### PR DESCRIPTION
I faced an issue with stacktrace first entry being incorrect.
Say in application we have something like that:
```
gitlab.com/project/api/repositories.(*ModelTranslation).Create
 	/service/repositories/model_translation.go:33
gitlab.com/project/api/services.(*Model).Create.func1
 	/service/services/model.go:68
github.com/go-pg/pg.(*Tx).RunInTransaction
 	/go/pkg/mod/github.com/go-pg/pg@v8.0.4+incompatible/tx.go:79
...
```

But Sentry received an exception with a bit different trace:
```
  File "/go/pkg/mod/github.com/pkg/errors@v0.8.1/errors.go", line 151, in WithStack
    callers(),
  File "/service/services/model.go", line 68, in func1
    err = modelTranslationRepo.Create(txCtx, mt)
  File "/go/pkg/mod/github.com/go-pg/pg@v8.0.4+incompatible/tx.go", line 79, in RunInTransaction
    if err := fn(tx); err != nil {
...
```

So the first entry in Sentry's trace leads to `pkg/errors`, but originally it was referring to the application code.
While trying to find the reason behind that I noticed stacktrace conversion in `raven-go` looked almost the same as in `logrus_sentry` except for a `- 1` part [here](https://github.com/getsentry/raven-go/blob/master/stacktrace.go#L66).
To be honest I'm not sure how exactly it works, but I did the same change for `logrus_sentry` and now I get correct stacktrace and it seems like all tests here still pass.