### PR TITLE
Convert merry stacktrace

### DIFF
--- a/sentry_test.go
+++ b/sentry_test.go
@@ -400,11 +400,16 @@ func (myStacktracerError) GetStacktrace() *raven.Stacktrace {
 	}
 }
 
-func TestConvertStackTrace(t *testing.T) {
+func TestConvertStack(t *testing.T) {
 	hook := SentryHook{}
 	expected := raven.NewStacktrace(0, 0, nil)
 	st := pkgerrors.New("-").(pkgErrorStackTracer).StackTrace()
-	ravenSt := hook.convertStackTrace(st)
+	stackFrames := []pkgerrors.Frame(st)
+	stack := make([]uintptr, len(stackFrames))
+	for i := 0; i < len(stack); i++ {
+		stack[i] = uintptr(stackFrames[i])
+	}
+	ravenSt := hook.convertStack(stack)
 
 	// Obscure the line numbes, so DeepEqual doesn't fail erroneously
 	for _, frame := range append(expected.Frames, ravenSt.Frames...) {


### PR DESCRIPTION
Added support to convert stacktrace from https://github.com/ansel1/merry errors.

We could in addition support a generic error interface that returns `[]uintptr`. This helps to convert the caller frames attached to error types while respecting stacktrace configuration settings.